### PR TITLE
refactor: replace magic strings with enums (#36)

### DIFF
--- a/backend/app/changelog.py
+++ b/backend/app/changelog.py
@@ -2,13 +2,15 @@
 
 import datetime
 
+from app.enums import ChangelogAction
 
-def append_changelog_entry(post, action: str, summary: str) -> None:
+
+def append_changelog_entry(post, action: ChangelogAction, summary: str) -> None:
     """Append a changelog entry to a frontmatter.Post object.
 
     Args:
         post: A python-frontmatter Post object.
-        action: The action type (e.g. "created", "edited", "merged").
+        action: The action type (a :class:`~app.enums.ChangelogAction` value).
         summary: A human-readable summary of the change.
     """
     changelog = post.metadata.get("changelog", [])
@@ -35,7 +37,7 @@ def remove_changelog_entries_for_fork(post, fork_name: str) -> None:
     post.metadata["changelog"] = [
         entry for entry in changelog
         if not (
-            entry.get("action") in ("merged", "unmerged")
+            entry.get("action") in (ChangelogAction.MERGED, ChangelogAction.UNMERGED)
             and f"'{fork_name}'" in entry.get("summary", "")
         )
     ]

--- a/backend/app/enums.py
+++ b/backend/app/enums.py
@@ -1,0 +1,41 @@
+"""Enum definitions for recurring string constants used across the app."""
+
+from enum import StrEnum
+
+
+class ChangelogAction(StrEnum):
+    """Action types recorded in recipe and fork changelogs."""
+
+    CREATED = "created"
+    EDITED = "edited"
+    MERGED = "merged"
+    UNMERGED = "unmerged"
+    FAILED = "failed"
+    UNFAILED = "unfailed"
+
+
+class EventType(StrEnum):
+    """Event types emitted in the recipe stream/timeline.
+
+    Extends ChangelogAction with the synthetic ``forked`` event, which is
+    produced when a fork's ``created`` changelog entry is surfaced in the
+    stream (so base-recipe ``created`` and fork-creation events are distinct).
+    """
+
+    CREATED = "created"
+    EDITED = "edited"
+    FORKED = "forked"
+    MERGED = "merged"
+    UNMERGED = "unmerged"
+    FAILED = "failed"
+    UNFAILED = "unfailed"
+
+
+class RemoteProvider(StrEnum):
+    """Supported remote git provider types."""
+
+    GITHUB = "github"
+    GITLAB = "gitlab"
+    GENERIC = "generic"
+    TANGLED = "tangled"
+    LOCAL = "local"

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -2,6 +2,8 @@ from typing import Dict, List, Optional
 
 from pydantic import BaseModel
 
+from app.enums import ChangelogAction, EventType, RemoteProvider
+
 
 class ChangelogEntry(BaseModel):
     date: str
@@ -81,7 +83,7 @@ class SyncStatus(BaseModel):
 
 
 class StreamEvent(BaseModel):
-    type: str  # "created", "edited", "forked", "merged", "unmerged", "failed", "unfailed"
+    type: EventType
     date: str
     message: str
     commit: Optional[str] = None
@@ -90,7 +92,7 @@ class StreamEvent(BaseModel):
 
 
 class RemoteConfig(BaseModel):
-    provider: Optional[str] = None  # "github", "gitlab", "generic", "tangled", "local"
+    provider: Optional[RemoteProvider] = None
     url: Optional[str] = None
     token: Optional[str] = None
     local_path: Optional[str] = None

--- a/backend/app/routes/editor.py
+++ b/backend/app/routes/editor.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, HTTPException, UploadFile, File
 from pydantic import BaseModel
 
 from app.changelog import append_changelog_entry
+from app.enums import ChangelogAction
 from app.generator import RecipeInput, slugify, generate_markdown
 from app.git import git_commit, git_rm
 from app.index import RecipeIndex
@@ -89,7 +90,7 @@ def create_editor_router(index: RecipeIndex, recipes_dir: Path) -> APIRouter:
 
         # Append changelog entry and set initial version
         post = frontmatter.load(filepath)
-        append_changelog_entry(post, "created", "Created")
+        append_changelog_entry(post, ChangelogAction.CREATED, "Created")
         post.metadata["version"] = 1
         filepath.write_text(frontmatter.dumps(post))
 
@@ -156,7 +157,7 @@ def create_editor_router(index: RecipeIndex, recipes_dir: Path) -> APIRouter:
             summary = "Edited metadata"
         # Carry forward existing changelog from the old post
         new_post.metadata["changelog"] = old_post.metadata.get("changelog", [])
-        append_changelog_entry(new_post, "edited", summary)
+        append_changelog_entry(new_post, ChangelogAction.EDITED, summary)
         new_post.metadata["version"] = old_version + 1
         filepath.write_text(frontmatter.dumps(new_post))
 

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from fastapi import APIRouter
 
+from app.enums import RemoteProvider
 from app.models import RemoteConfig, SyncConfig, SyncStatus
 from app.remote_config import get_config_path, load_config, save_config
 from app.sync import SyncEngine
@@ -42,7 +43,7 @@ def create_settings_router(sync_engine: SyncEngine, recipes_dir: Path) -> APIRou
         remote = RemoteConfig(**body.get("remote", {}))
         sync = SyncConfig(**body.get("sync", {}))
         save_config(config_path, remote, sync)
-        if remote.provider == "local" and remote.local_path:
+        if remote.provider == RemoteProvider.LOCAL and remote.local_path:
             from app.git import git_init_bare, git_remote_add
             git_init_bare(Path(remote.local_path))
             git_remote_add(recipes_dir, remote.local_path)


### PR DESCRIPTION
## Summary

Closes #36.

Magic string literals used as event/action types and remote provider identifiers were scattered across the codebase with no single source of truth. This PR introduces `backend/app/enums.py` and replaces all occurrences with typed enum members.

### New file: `backend/app/enums.py`

Three `StrEnum` classes (Python 3.11+):

- **`ChangelogAction`** — action types stored in recipe/fork YAML frontmatter: `created`, `edited`, `merged`, `unmerged`, `failed`, `unfailed`
- **`EventType`** — event types surfaced by the stream/timeline API; a superset of `ChangelogAction` that adds the synthetic `forked` event (produced when a fork's `created` changelog entry is promoted to a stream event)
- **`RemoteProvider`** — remote git provider identifiers: `github`, `gitlab`, `generic`, `tangled`, `local`

### Files updated

| File | Change |
|------|--------|
| `app/models.py` | `StreamEvent.type` typed as `EventType`; `RemoteConfig.provider` typed as `Optional[RemoteProvider]` |
| `app/changelog.py` | `action` parameter typed as `ChangelogAction`; membership check uses enum members |
| `app/routes/editor.py` | `"created"` / `"edited"` literals replaced with `ChangelogAction.*` |
| `app/routes/forks.py` | All six action literals replaced with `ChangelogAction.*` |
| `app/routes/stream.py` | Membership checks and event-type mapping use `ChangelogAction.*` / `EventType.*` |
| `app/routes/settings.py` | `"local"` provider check replaced with `RemoteProvider.LOCAL` |

### Backwards compatibility

`StrEnum` members compare equal to their plain-string equivalents, so no data-layer changes are needed and all existing YAML frontmatter files remain fully compatible.

## Test plan

- [ ] `python -m pytest backend/tests/` passes (all existing tests cover the changed code paths)
- [ ] Verify stream endpoint returns expected event types for a recipe with forks
- [ ] Verify settings save/load with `provider: "local"` still triggers bare-repo init