### PR TITLE
fix: add SSRF protection to recipe scraper (#26)

### DIFF
--- a/backend/tests/test_scraper.py
+++ b/backend/tests/test_scraper.py
@@ -1,9 +1,12 @@
+import ipaddress
+import socket
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import httpx
+import pytest
 
-from app.scraper import scrape_recipe, download_image
+from app.scraper import scrape_recipe, download_image, validate_url, SSRFError
 
 
 def _make_mock_scraper(
@@ -31,10 +34,223 @@ def _make_mock_scraper(
     return scraper
 
 
+# ---------------------------------------------------------------------------
+# validate_url — SSRF protection tests
+# ---------------------------------------------------------------------------
+
+class TestValidateUrl:
+    """Tests for the SSRF-protection URL validator."""
+
+    # --- scheme checks ---
+
+    def test_http_scheme_allowed(self):
+        """http:// URLs with a public hostname are allowed."""
+        with patch("app.scraper.socket.getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+            validate_url("http://example.com/recipe")  # should not raise
+
+    def test_https_scheme_allowed(self):
+        """https:// URLs with a public hostname are allowed."""
+        with patch("app.scraper.socket.getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+            validate_url("https://example.com/recipe")  # should not raise
+
+    def test_ftp_scheme_rejected(self):
+        """ftp:// URLs must be rejected."""
+        with pytest.raises(SSRFError, match="scheme"):
+            validate_url("ftp://example.com/file.txt")
+
+    def test_file_scheme_rejected(self):
+        """file:// URLs must be rejected (local file access)."""
+        with pytest.raises(SSRFError, match="scheme"):
+            validate_url("file:///etc/passwd")
+
+    def test_gopher_scheme_rejected(self):
+        """gopher:// URLs must be rejected."""
+        with pytest.raises(SSRFError, match="scheme"):
+            validate_url("gopher://example.com")
+
+    def test_empty_scheme_rejected(self):
+        """URLs without a scheme must be rejected."""
+        with pytest.raises(SSRFError):
+            validate_url("//example.com/recipe")
+
+    # --- localhost / loopback ---
+
+    def test_localhost_hostname_rejected(self):
+        """'localhost' hostname must be rejected without DNS lookup."""
+        with pytest.raises(SSRFError, match="not allowed"):
+            validate_url("http://localhost/admin")
+
+    def test_localhost_uppercase_rejected(self):
+        """'LOCALHOST' (case-insensitive) must be rejected."""
+        with pytest.raises(SSRFError, match="not allowed"):
+            validate_url("http://LOCALHOST/admin")
+
+    def test_127_0_0_1_rejected(self):
+        """Literal 127.0.0.1 must be rejected (loopback)."""
+        with patch("app.scraper.socket.getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(None, None, None, None, ("127.0.0.1", 0))]
+            with pytest.raises(SSRFError, match="private/internal"):
+                validate_url("http://127.0.0.1/secret")
+
+    def test_127_0_0_2_rejected(self):
+        """Any 127.x.x.x address must be rejected (loopback range)."""
+        with patch("app.scraper.socket.getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(None, None, None, None, ("127.0.0.2", 0))]
+            with pytest.raises(SSRFError, match="private/internal"):
+                validate_url("http://127.0.0.2/")
+
+    def test_ipv6_loopback_rejected(self):
+        """IPv6 loopback ::1 must be rejected."""
+        with patch("app.scraper.socket.getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(None, None, None, None, ("::1", 0))]
+            with pytest.raises(SSRFError, match="private/internal"):
+                validate_url("http://[::1]/secret")
+
+    # --- RFC 1918 private ranges ---
+
+    def test_10_x_rejected(self):
+        """10.0.0.0/8 addresses must be rejected."""
+        with patch("app.scraper.socket.getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(None, None, None, None, ("10.1.2.3", 0))]
+            with pytest.raises(SSRFError, match="private/internal"):
+                validate_url("http://internal.example.com/")
+
+    def test_172_16_rejected(self):
+        """172.16.0.0/12 addresses must be rejected."""
+        with patch("app.scraper.socket.getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(None, None, None, None, ("172.20.0.1", 0))]
+            with pytest.raises(SSRFError, match="private/internal"):
+                validate_url("http://internal.corp/resource")
+
+    def test_172_31_rejected(self):
+        """172.31.255.255 (last address of 172.16/12) must be rejected."""
+        with patch("app.scraper.socket.getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(None, None, None, None, ("172.31.255.255", 0))]
+            with pytest.raises(SSRFError, match="private/internal"):
+                validate_url("http://internal.corp/resource")
+
+    def test_172_15_allowed(self):
+        """172.15.x.x is NOT in the 172.16/12 range and should be allowed."""
+        with patch("app.scraper.socket.getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(None, None, None, None, ("172.15.0.1", 0))]
+            validate_url("https://example.com/recipe")  # should not raise
+
+    def test_192_168_rejected(self):
+        """192.168.0.0/16 addresses must be rejected."""
+        with patch("app.scraper.socket.getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(None, None, None, None, ("192.168.1.100", 0))]
+            with pytest.raises(SSRFError, match="private/internal"):
+                validate_url("http://router.local/api")
+
+    # --- link-local ---
+
+    def test_169_254_rejected(self):
+        """169.254.x.x (APIPA / link-local) must be rejected."""
+        with patch("app.scraper.socket.getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(None, None, None, None, ("169.254.169.254", 0))]
+            with pytest.raises(SSRFError, match="private/internal"):
+                validate_url("http://metadata.example.com/latest/meta-data/")
+
+    # --- DNS rebinding: hostname resolves to private IP ---
+
+    def test_dns_rebinding_blocked(self):
+        """A hostname that resolves to an internal IP must be rejected."""
+        with patch("app.scraper.socket.getaddrinfo") as mock_dns:
+            # e.g. attacker.com → 192.168.1.1
+            mock_dns.return_value = [(None, None, None, None, ("192.168.1.1", 0))]
+            with pytest.raises(SSRFError, match="private/internal"):
+                validate_url("https://totally-legit.attacker.com/recipe")
+
+    def test_dns_resolution_failure_raises(self):
+        """If DNS resolution fails, SSRFError is raised (fail-closed)."""
+        with patch("app.scraper.socket.getaddrinfo") as mock_dns:
+            mock_dns.side_effect = socket.gaierror("Name or service not known")
+            with pytest.raises(SSRFError, match="Could not resolve"):
+                validate_url("https://nonexistent.invalid/recipe")
+
+    # --- public IPs are allowed ---
+
+    def test_public_ipv4_allowed(self):
+        """A public IPv4 address must be allowed."""
+        with patch("app.scraper.socket.getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+            validate_url("https://example.com/recipe")  # should not raise
+
+    def test_public_ipv6_allowed(self):
+        """A public IPv6 address must be allowed."""
+        with patch("app.scraper.socket.getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(None, None, None, None, ("2606:2800:220:1:248:1893:25c8:1946", 0))]
+            validate_url("https://example.com/recipe")  # should not raise
+
+    def test_multiple_resolved_ips_one_private_rejected(self):
+        """If any resolved IP is private, the whole URL is rejected."""
+        with patch("app.scraper.socket.getaddrinfo") as mock_dns:
+            mock_dns.return_value = [
+                (None, None, None, None, ("93.184.216.34", 0)),  # public
+                (None, None, None, None, ("10.0.0.1", 0)),       # private!
+            ]
+            with pytest.raises(SSRFError, match="private/internal"):
+                validate_url("https://suspicious.example.com/recipe")
+
+
+# ---------------------------------------------------------------------------
+# scrape_recipe — integration with URL validation
+# ---------------------------------------------------------------------------
+
+class TestScrapeRecipeSSRF:
+    """Tests that scrape_recipe rejects blocked URLs before fetching."""
+
+    def test_scrape_recipe_rejects_localhost(self):
+        """scrape_recipe must raise SSRFError for localhost URLs."""
+        with pytest.raises(SSRFError):
+            scrape_recipe("http://localhost/admin")
+
+    def test_scrape_recipe_rejects_private_ip(self):
+        """scrape_recipe must raise SSRFError when DNS resolves to private IP."""
+        with patch("app.scraper.socket.getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(None, None, None, None, ("192.168.1.1", 0))]
+            with pytest.raises(SSRFError):
+                scrape_recipe("https://internal.corp/recipe")
+
+    def test_scrape_recipe_rejects_file_scheme(self):
+        """scrape_recipe must raise SSRFError for file:// URLs."""
+        with pytest.raises(SSRFError, match="scheme"):
+            scrape_recipe("file:///etc/passwd")
+
+    @patch("app.scraper.socket.getaddrinfo")
+    @patch("app.scraper.scrape_html")
+    @patch("app.scraper.httpx.get")
+    def test_scrape_recipe_allows_public_url(self, mock_get, mock_scrape_html, mock_dns):
+        """scrape_recipe proceeds normally for public URLs."""
+        mock_dns.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+
+        mock_response = MagicMock()
+        mock_response.text = "<html>recipe page</html>"
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        mock_scraper = _make_mock_scraper()
+        mock_scrape_html.return_value = mock_scraper
+
+        result = scrape_recipe("https://example.com/recipe")
+
+        assert result["title"] == "Test Recipe"
+        assert result["source"] == "https://example.com/recipe"
+
+
+# ---------------------------------------------------------------------------
+# Existing scraper tests (unchanged behaviour)
+# ---------------------------------------------------------------------------
+
+@patch("app.scraper.socket.getaddrinfo")
 @patch("app.scraper.scrape_html")
 @patch("app.scraper.httpx.get")
-def test_scrape_recipe_with_mock(mock_get, mock_scrape_html):
+def test_scrape_recipe_with_mock(mock_get, mock_scrape_html, mock_dns):
     """Full successful scrape returns all fields populated."""
+    mock_dns.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+
     mock_response = MagicMock()
     mock_response.text = "<html>recipe page</html>"
     mock_response.raise_for_status = MagicMock()
@@ -67,10 +283,12 @@ def test_scrape_recipe_with_mock(mock_get, mock_scrape_html):
     )
 
 
+@patch("app.scraper.socket.getaddrinfo")
 @patch("app.scraper.scrape_html")
 @patch("app.scraper.httpx.get")
-def test_scrape_recipe_handles_failure(mock_get, mock_scrape_html):
+def test_scrape_recipe_handles_failure(mock_get, mock_scrape_html, mock_dns):
     """Network failure falls back to online mode; if that also fails, returns empty result."""
+    mock_dns.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
     mock_get.side_effect = httpx.ConnectError("Connection refused")
     mock_scrape_html.side_effect = Exception("Online mode also failed")
 
@@ -89,10 +307,13 @@ def test_scrape_recipe_handles_failure(mock_get, mock_scrape_html):
     assert result["notes"] is None
 
 
+@patch("app.scraper.socket.getaddrinfo")
 @patch("app.scraper.scrape_html")
 @patch("app.scraper.httpx.get")
-def test_scrape_recipe_handles_partial_data(mock_get, mock_scrape_html):
+def test_scrape_recipe_handles_partial_data(mock_get, mock_scrape_html, mock_dns):
     """Scraper that only has title and ingredients still returns partial data."""
+    mock_dns.return_value = [(None, None, None, None, ("93.184.216.34", 0))]
+
     mock_response = MagicMock()
     mock_response.text = "<html>partial recipe</html>"
     mock_response.raise_for_status = MagicMock()


### PR DESCRIPTION
## Summary

Fixes #26 — adds URL validation to `backend/app/scraper.py` before any outbound HTTP request to prevent Server-Side Request Forgery (SSRF) attacks.

### Changes

**`backend/app/scraper.py`**
- New `SSRFError(ValueError)` exception class
- New `_BLOCKED_NETWORKS` list covering all private/reserved IP ranges (RFC 1918, loopback, link-local, IPv6 unique-local, IANA special-purpose)
- New `_is_private_ip(addr)` helper checks an `ipaddress` object against all blocked networks
- New `validate_url(url)` function that:
  - Restricts schemes to `http`/`https` only (blocks `file://`, `ftp://`, `gopher://`, etc.)
  - Rejects `localhost`/`ip6-localhost` by name before any DNS lookup
  - Resolves hostname via `socket.getaddrinfo` (returns all A/AAAA records)
  - Checks every resolved IP against blocked networks — fail-closed (DNS error → SSRFError)
  - Raises `SSRFError` for any violation
- `scrape_recipe()` now calls `validate_url()` before any network I/O; re-raises `SSRFError` so it is not silently swallowed by the fallback handler

**`backend/tests/test_scraper.py`**
- `TestValidateUrl` class: 20 tests covering scheme rejection, localhost, 127.x, ::1, RFC 1918 ranges (10/8, 172.16/12, 192.168/16), link-local (169.254/16), DNS rebinding, DNS resolution failures, public IPv4/IPv6 allow-paths, and multi-address partial-private rejection
- `TestScrapeRecipeSSRF` class: 4 integration tests confirming `scrape_recipe` propagates validation errors
- Existing tests updated to mock `socket.getaddrinfo` so they pass in offline/sandboxed CI environments

### Blocked networks

| Network | Reason |
|---|---|
| `10.0.0.0/8` | RFC 1918 private |
| `172.16.0.0/12` | RFC 1918 private |
| `192.168.0.0/16` | RFC 1918 private |
| `127.0.0.0/8` | Loopback |
| `::1/128` | IPv6 loopback |
| `169.254.0.0/16` | Link-local / AWS metadata endpoint |
| `fe80::/10` | IPv6 link-local |
| `fc00::/7` | IPv6 unique-local |
| `0.0.0.0/8`, `100.64.0.0/10`, `192.0.0.0/24`, `198.18.0.0/15`, `198.51.100.0/24`, `203.0.113.0/24`, `240.0.0.0/4`, `255.255.255.255/32` | IANA special-purpose / reserved |

## Test plan

- [ ] All new `TestValidateUrl` tests pass (20 tests)
- [ ] All new `TestScrapeRecipeSSRF` tests pass (4 tests)
- [ ] All existing scraper tests continue to pass
- [ ] Manually verify that `http://localhost/`, `http://192.168.1.1/`, and `http://169.254.169.254/` are rejected with `SSRFError`
- [ ] Manually verify that a real recipe URL still scrapes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)