### PR TITLE
fix: add file size limit to image uploads (#37)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -7,6 +7,7 @@ class Settings(BaseSettings):
     recipes_dir: Path = Path(__file__).resolve().parent.parent.parent / "recipes"
     host: str = "0.0.0.0"
     port: int = 8000
+    max_upload_size_mb: int = 10
 
     model_config = {"env_prefix": "FORKS_"}
 


### PR DESCRIPTION
## Summary

- Adds `MAX_UPLOAD_SIZE_MB` setting to `config.py` (default: 10MB, configurable via `FORKS_MAX_UPLOAD_SIZE_MB` env var)
- Enforces the limit in `POST /api/images/upload` by reading the file content and checking `len(content)` before writing to disk
- Returns HTTP 413 with a clear error message when the limit is exceeded

## Changes

- `backend/app/config.py` — add `max_upload_size_mb: int = 10` to `Settings`
- `backend/app/routes/editor.py` — import `settings`, check file size after `await file.read()`, raise 413 if over limit
- `backend/tests/test_editor_routes.py` — three new tests: successful small upload, oversized upload → 413, non-image content-type → 400

## Test plan

- [ ] `test_upload_image_within_limit` — small JPEG under limit returns 200
- [ ] `test_upload_image_exceeds_limit` — file over limit returns 413 with "too large" message
- [ ] `test_upload_image_not_an_image` — text/plain content-type returns 400

Fixes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)