### PR TITLE
feat: add configurable CORS middleware (#27)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,5 +1,7 @@
 from pathlib import Path
+from typing import List
 
+from pydantic import field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -7,6 +9,18 @@ class Settings(BaseSettings):
     recipes_dir: Path = Path(__file__).resolve().parent.parent.parent / "recipes"
     host: str = "0.0.0.0"
     port: int = 8000
+
+    # CORS origins — comma-separated list of allowed origins.
+    # Defaults to ["*"] which is fine for a self-hosted home server.
+    # To restrict access, set FORKS_CORS_ORIGINS="http://192.168.1.10:3000,http://forks.local"
+    cors_origins: List[str] = ["*"]
+
+    @field_validator("cors_origins", mode="before")
+    @classmethod
+    def parse_cors_origins(cls, v: object) -> object:
+        if isinstance(v, str):
+            return [origin.strip() for origin in v.split(",") if origin.strip()]
+        return v
 
     model_config = {"env_prefix": "FORKS_"}
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
@@ -34,6 +35,17 @@ def create_app(recipes_dir: Optional[Path] = None) -> FastAPI:
     # standardized {"error": "...", "status": ...} format.
     app.add_exception_handler(StarletteHTTPException, http_exception_handler)
     app.add_exception_handler(RequestValidationError, validation_exception_handler)
+
+    # Configure CORS.  Origins are controlled via the FORKS_CORS_ORIGINS env var
+    # (comma-separated).  Defaults to ["*"] which is appropriate for a self-hosted
+    # home server; restrict to specific origins in production if desired.
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=settings.cors_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
 
     recipes_path = recipes_dir or settings.recipes_dir
 

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,0 +1,104 @@
+"""Tests for CORS middleware configuration."""
+
+import subprocess
+import textwrap
+from unittest import mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+
+
+SIMPLE_RECIPE = textwrap.dedent("""\
+    ---
+    title: Simple Soup
+    tags: [soup]
+    ---
+
+    # Simple Soup
+
+    ## Ingredients
+
+    - 1 cup water
+
+    ## Instructions
+
+    1. Boil water.
+""")
+
+
+@pytest.fixture
+def tmp_recipes(tmp_path):
+    (tmp_path / "images").mkdir()
+    (tmp_path / "simple-soup.md").write_text(SIMPLE_RECIPE)
+
+    subprocess.run(["git", "init"], cwd=str(tmp_path), capture_output=True)
+    subprocess.run(["git", "add", "-A"], cwd=str(tmp_path), capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Initial commit"],
+        cwd=str(tmp_path),
+        capture_output=True,
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def client(tmp_recipes):
+    app = create_app(recipes_dir=tmp_recipes)
+    return TestClient(app)
+
+
+def test_cors_headers_present_with_wildcard_default(client):
+    """Default config (allow *) should include CORS headers on preflight."""
+    resp = client.options(
+        "/api/recipes",
+        headers={
+            "Origin": "http://example.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert resp.headers.get("access-control-allow-origin") in ("*", "http://example.com")
+
+
+def test_cors_allow_origin_on_regular_request(client):
+    """Regular requests from an origin should receive the CORS header."""
+    resp = client.get(
+        "/api/recipes",
+        headers={"Origin": "http://192.168.1.10:3000"},
+    )
+    assert resp.status_code == 200
+    assert "access-control-allow-origin" in resp.headers
+
+
+def test_cors_specific_origin(tmp_recipes):
+    """When CORS_ORIGINS is set to a specific origin, that origin is reflected."""
+    with mock.patch("app.config.settings") as mock_settings:
+        mock_settings.cors_origins = ["http://192.168.1.10:3000"]
+        mock_settings.recipes_dir = tmp_recipes
+
+        app = create_app(recipes_dir=tmp_recipes)
+        restricted_client = TestClient(app)
+
+    resp = restricted_client.get(
+        "/api/recipes",
+        headers={"Origin": "http://192.168.1.10:3000"},
+    )
+    assert resp.status_code == 200
+    assert resp.headers.get("access-control-allow-origin") == "http://192.168.1.10:3000"
+
+
+def test_cors_origins_env_var_parsing():
+    """FORKS_CORS_ORIGINS env var should be parsed from a comma-separated string."""
+    from app.config import Settings
+
+    s = Settings(cors_origins="http://foo.local,http://bar.local:3000")  # type: ignore[call-arg]
+    assert s.cors_origins == ["http://foo.local", "http://bar.local:3000"]
+
+
+def test_cors_origins_default_is_wildcard():
+    """Default cors_origins should be ['*'] for self-hosted deployments."""
+    from app.config import Settings
+
+    s = Settings()
+    assert s.cors_origins == ["*"]


### PR DESCRIPTION
## Summary

- Adds `CORSMiddleware` to the FastAPI app in `main.py`
- Introduces `cors_origins` setting in `config.py`, configurable via `FORKS_CORS_ORIGINS` env var (comma-separated list)
- Defaults to `["*"]` for self-hosted home server use — no config needed out of the box
- Documents how to restrict origins in a comment for production deployments
- Adds `backend/tests/test_cors.py` with 5 tests covering preflight headers, regular request headers, specific-origin reflection, env var parsing, and default value

## Configuration

To restrict to specific origins, set:

```
FORKS_CORS_ORIGINS=http://192.168.1.10:3000,http://forks.local
```

Leave unset (or set to `*`) to allow all origins — the default, recommended for home server use.

## Test plan

- [ ] `cd backend && pytest tests/test_cors.py -v` — all 5 tests pass
- [ ] Start the server, make a cross-origin request from browser devtools, verify `Access-Control-Allow-Origin` header is present
- [ ] Set `FORKS_CORS_ORIGINS` to a specific origin and verify only that origin is reflected

Closes #27